### PR TITLE
ログイン済みユーザーがトップページにアクセスした際のフィルター問題を解消

### DIFF
--- a/src/main/java/filter/AuthenticateFilter.java
+++ b/src/main/java/filter/AuthenticateFilter.java
@@ -112,18 +112,20 @@ public class AuthenticateFilter implements Filter {
                 httpServletResponse.sendRedirect("/users");
             }
         }
+        else if (servletPath.equals("/")) {
+            if (currentUser == null) {
+                httpServletResponse.sendRedirect("/index");
+            } else {
+                httpServletResponse.sendRedirect("/users");
+            }
+        }
         // ログインしないとダメな画面にアクセスしたとき
         else {
             if (currentUser == null) {
                 // リダイレクト
                 httpServletResponse.sendRedirect("/index");
-            } else {
-                if (servletPath.equals("/")) {
-                    httpServletResponse.sendRedirect("/users");
-                } else {
-                    chain.doFilter(req, resp);
-                }
             }
+                chain.doFilter(req, resp);
         }
     }
 

--- a/src/main/java/filter/AuthenticateFilter.java
+++ b/src/main/java/filter/AuthenticateFilter.java
@@ -118,7 +118,11 @@ public class AuthenticateFilter implements Filter {
                 // リダイレクト
                 httpServletResponse.sendRedirect("/index");
             } else {
-                chain.doFilter(req, resp);
+                if (servletPath.equals("/")) {
+                    httpServletResponse.sendRedirect("/users");
+                } else {
+                    chain.doFilter(req, resp);
+                }
             }
         }
     }


### PR DESCRIPTION
# 問題
1. ログイン済みユーザーがhttps://m218113.com/にアクセス
2. AuthenticateFilter.javaでフィルターにかからずアノテーションが"/"のままリクエストされてしまい，404NotFoundとなる

# 解決策
AuthenticateFilter.javaにアノテーション"/"の分岐を追加